### PR TITLE
Add option to poll new connected devices and enable them as input

### DIFF
--- a/Avalonia.LibInputExperiments/Avalonia.LibInputExperiments.csproj
+++ b/Avalonia.LibInputExperiments/Avalonia.LibInputExperiments.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <LangVersion>11</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <AvaloniaAccessUnstablePrivateApis>true</AvaloniaAccessUnstablePrivateApis>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-      <PackageReference Include="Avalonia.LinuxFramebuffer" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia" Version="11.0.10" />
+        <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.10" />
     </ItemGroup>
 
 </Project>

--- a/Avalonia.LibInputExperiments/Avalonia.LibInputExperiments.csproj
+++ b/Avalonia.LibInputExperiments/Avalonia.LibInputExperiments.csproj
@@ -1,15 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <LangVersion>11</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <AvaloniaAccessUnstablePrivateApis>true</AvaloniaAccessUnstablePrivateApis>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="11.0.10" />
-      <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.10" />
+      <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+      <PackageReference Include="Avalonia.LinuxFramebuffer" Version="$(AvaloniaVersion)" />
     </ItemGroup>
 
 </Project>

--- a/Avalonia.LibInputExperiments/LibInputBackend.cs
+++ b/Avalonia.LibInputExperiments/LibInputBackend.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
@@ -10,93 +12,134 @@ using static Avalonia.LibInputExperiments.LibInputNativeUnsafeMethods;
 
 namespace Avalonia.LibInputExperiments
 {
-  public partial class LibInputBackend : IInputBackend
-  {
-    private IScreenInfoProvider? _screen;
-    private IInputRoot? _inputRoot;
-    private const string LibInput = nameof(LinuxFramebuffer) + "/" + nameof(Input) + "/" + nameof(LibInput);
-    private Action<RawInputEventArgs>? _onInput;
-    private readonly LibInputBackendOptions? _options;
-
-    public LibInputBackend(LibInputBackendOptions? options = default)
+    public partial class LibInputBackend : IInputBackend
     {
-      Console.WriteLine("Using experimental LibInput backend");
-      _options = options;
-    }
-    
-    private unsafe void InputThread(IntPtr ctx, LibInputBackendOptions options)
-    {
-      Console.WriteLine("Starting InputThread");
-      SetupKeyboard(options.Keyboard);
-      var fd = libinput_get_fd(ctx);
+        private IScreenInfoProvider? _screen;
+        private IInputRoot? _inputRoot;
+        private const string LibInput = nameof(LinuxFramebuffer) + "/" + nameof(Input) + "/" + nameof(LibInput);
+        private Action<RawInputEventArgs>? _onInput;
+        private readonly LibInputBackendOptions? _options;
 
-      foreach (var f in options.Events!)
-        libinput_path_add_device(ctx, f);
-      while (true)
-      {
-        IntPtr ev;
-        libinput_dispatch(ctx);
-        while ((ev = libinput_get_event(ctx)) != IntPtr.Zero)
+        public LibInputBackend(LibInputBackendOptions? options = default)
         {
-          var type = libinput_event_get_type(ev);
-
-          if (type >= LibInputEventType.LIBINPUT_EVENT_KEYBOARD_KEY
-              && type <= LibInputEventType.LIBINPUT_EVENT_KEYBOARD_KEY)
-            HandleKeyboard(ev, type);
-
-          if (type >= LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN &&
-              type <= LibInputEventType.LIBINPUT_EVENT_TOUCH_CANCEL)
-            HandleTouch(ev, type);
-
-          if (type >= LibInputEventType.LIBINPUT_EVENT_POINTER_MOTION
-              && type <= LibInputEventType.LIBINPUT_EVENT_POINTER_AXIS)
-            HandlePointer(ev, type);
-
-          // if (type >= LibInputEventType.LIBINPUT_EVENT_TABLET_TOOL_AXIS
-          //     && type <= LibInputEventType.LIBINPUT_EVENT_TABLET_TOOL_BUTTON)
-          //     HandleTabletTool(ev, type);
-          //
-          // if (type >= LibInputEventType.LIBINPUT_EVENT_TABLET_PAD_BUTTON
-          //     && type <= LibInputEventType.LIBINPUT_EVENT_TABLET_PAD_STRIP)
-          //     HandleTabletPad(ev, type);
-          //
-          // if (type >= LibInputEventType.LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN
-          //     && type <= LibInputEventType.LIBINPUT_EVENT_GESTURE_PINCH_END)
-          //     HandleGesture(ev, type);
-
-          libinput_event_destroy(ev);
-          libinput_dispatch(ctx);
+            _options = options;
         }
 
-        pollfd pfd = new pollfd { fd = fd, events = 1 };
-        NativeUnsafeMethods.poll(&pfd, new IntPtr(1), 10);
-      }
-    }
+        private string[] GetAvailableEvents()
+        {
+            return Directory.GetFiles("/dev/input", "event*");
+        }
 
-    private void ScheduleInput(RawInputEventArgs ev) => _onInput?.Invoke(ev);
+        private unsafe void InputThread(IntPtr ctx, LibInputBackendOptions options)
+        {
+            SetupKeyboard(options.Keyboard);
+            var fd = libinput_get_fd(ctx);
 
-    public void Initialize(IScreenInfoProvider screen, Action<RawInputEventArgs> onInput)
-    {
-      _screen = screen;
-      _onInput = onInput;
-      var ctx = libinput_path_create_context();
-      var options = new LibInputBackendOptions()
-      {
-        Events = _options?.Events is null
-          ? Directory.GetFiles("/dev/input", "event*")
-          : _options.Events,
-        Keyboard = _options?.Keyboard ?? new LibInputKeyboardConfiguration()
-      };
-      new Thread(() => InputThread(ctx, options))
-      {
-        Name = "Input Manager Worker",
-        IsBackground = true
-      }.Start();
-    }
+            var activeEvents = new Dictionary<string, IntPtr>();
 
-    public void SetInputRoot(IInputRoot root)
-    {
-      _inputRoot = root;
+            foreach (var f in options.Events!)
+            {
+                var instance = libinput_path_add_device(ctx, f);
+                activeEvents.TryAdd(f, instance);
+            }
+
+            var lastPoolUpdate = DateTime.Now;
+            
+            while (true)
+            {
+                if (options.ListenEventsChanges && (DateTime.Now - lastPoolUpdate).TotalMilliseconds >= options.ListenEventsChangesInterval)
+                {
+                    var events = GetAvailableEvents();
+
+                    // Checks if the get events and active events both contain same events
+                    foreach (var f in activeEvents.Keys)
+                    {
+                        if (events.Contains(f)) continue;
+                        if (activeEvents.Remove(f, out var inputPtr))
+                        {
+                            // This create segmentation fault, not sure how to handle this
+                            // For now we do not remove old devices ptr
+                            /*if (inputPtr != IntPtr.Zero)
+                            {
+                                libinput_path_remove_device(inputPtr);
+                            }*/
+                        }
+                    }
+                    
+                    // Adds events if not present in active events
+                    foreach (var f in events)
+                    {
+                        if (activeEvents.ContainsKey(f)) continue;
+                        var inputPtr = libinput_path_add_device(ctx, f);
+                        activeEvents.TryAdd(f, inputPtr);
+                    }
+                    lastPoolUpdate = DateTime.Now;
+                }
+
+                IntPtr ev;
+                libinput_dispatch(ctx);
+                while ((ev = libinput_get_event(ctx)) != IntPtr.Zero)
+                {
+                    var type = libinput_event_get_type(ev);
+
+                    if (type >= LibInputEventType.LIBINPUT_EVENT_KEYBOARD_KEY
+                        && type <= LibInputEventType.LIBINPUT_EVENT_KEYBOARD_KEY)
+                        HandleKeyboard(ev, type);
+
+                    if (type >= LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN &&
+                        type <= LibInputEventType.LIBINPUT_EVENT_TOUCH_CANCEL)
+                        HandleTouch(ev, type);
+
+                    if (type >= LibInputEventType.LIBINPUT_EVENT_POINTER_MOTION
+                        && type <= LibInputEventType.LIBINPUT_EVENT_POINTER_AXIS)
+                        HandlePointer(ev, type);
+
+                    // if (type >= LibInputEventType.LIBINPUT_EVENT_TABLET_TOOL_AXIS
+                    //     && type <= LibInputEventType.LIBINPUT_EVENT_TABLET_TOOL_BUTTON)
+                    //     HandleTabletTool(ev, type);
+                    //
+                    // if (type >= LibInputEventType.LIBINPUT_EVENT_TABLET_PAD_BUTTON
+                    //     && type <= LibInputEventType.LIBINPUT_EVENT_TABLET_PAD_STRIP)
+                    //     HandleTabletPad(ev, type);
+                    //
+                    // if (type >= LibInputEventType.LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN
+                    //     && type <= LibInputEventType.LIBINPUT_EVENT_GESTURE_PINCH_END)
+                    //     HandleGesture(ev, type);
+
+                    libinput_event_destroy(ev);
+                    libinput_dispatch(ctx);
+                }
+
+                pollfd pfd = new pollfd { fd = fd, events = 1 };
+                NativeUnsafeMethods.poll(&pfd, new IntPtr(1), 10);
+            }
+        }
+
+        private void ScheduleInput(RawInputEventArgs ev) => _onInput?.Invoke(ev);
+
+        public void Initialize(IScreenInfoProvider screen, Action<RawInputEventArgs> onInput)
+        {
+            _screen = screen;
+            _onInput = onInput;
+            var ctx = libinput_path_create_context();
+            var options = new LibInputBackendOptions()
+            {
+                ListenEventsChanges = _options?.ListenEventsChanges ?? false,
+                ListenEventsChangesInterval = _options?.ListenEventsChangesInterval ?? 5000,
+                Events = _options?.Events ?? GetAvailableEvents(),
+                Keyboard = _options?.Keyboard ?? new LibInputKeyboardConfiguration()
+            };
+
+            new Thread(() => InputThread(ctx, options))
+            {
+                Name = "Input Manager Worker",
+                IsBackground = true
+            }.Start();
+        }
+
+        public void SetInputRoot(IInputRoot root)
+        {
+            _inputRoot = root;
+        }
     }
-  }
 }

--- a/Avalonia.LibInputExperiments/LibInputBackendOptions.cs
+++ b/Avalonia.LibInputExperiments/LibInputBackendOptions.cs
@@ -9,6 +9,17 @@ namespace Avalonia.LibInputExperiments;
 public sealed record class LibInputBackendOptions
 {
     /// <summary>
+    /// Sets to listen for event changes, if true it will listen for events changes and register them to make the device work without restarting the application.
+    /// </summary>
+    public bool ListenEventsChanges { get; init; }
+
+    /// <summary>
+    /// Sets the listen for event changes interval in milliseconds.<br/>
+    /// Requires <see cref="ListenEventsChanges"/> to be true.
+    /// </summary>
+    public int ListenEventsChangesInterval { get; init; } = 5000;
+
+    /// <summary>
     /// List Events of events handler to monitoring eg: /dev/eventX.
     /// </summary>
     public IReadOnlyList<string>? Events { get; init; } = null;


### PR DESCRIPTION
Current implementation only scans and add devices on startup and they stay fixed.
If a device is disconnected or replaced, eg: Keyboard, it won't work until the app is restarted which is not convenient in most of applications.

In this PR I add a option to enable the auto polling and at which interval it should do it. It will scan devices and compare both active and scanned devices. Absent devices are removed and new devices are added to the active devices.
It works flawless with bluetooth and usb.

I created a dictionary to store the device `IntPtr` and tried to dispose when device is lost, however it raise a Segmentation fault error. So I always add new device and it seem to work fine.